### PR TITLE
Use nonroot user to run Valfisk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ RUN cargo build --target x86_64-unknown-linux-musl --release --locked
 FROM gcr.io/distroless/static:latest
 COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/valfisk /valfisk
 
+USER nonroot
+
 CMD ["/valfisk"]


### PR DESCRIPTION
Distroless uses root by default, but it does have a `nonroot` user